### PR TITLE
A true zookeeper/kafka cluster

### DIFF
--- a/kafka/LICENSE
+++ b/kafka/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2016, Russ Miles & Sylvain Hellegouarch
+All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met: 
+
+ * Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+ * Redistributions in binary form must reproduce the above copyright 
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the distribution. 
+ * Neither the name of this package nor the names of its contributors may be used 
+   to endorse or promote products derived from this software without 
+   specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -20,16 +20,38 @@ infrastructure.
 Run the Kafka cluster on Kubernetes
 -----------------------------------
 
-### Kubernetes service
+### Zookeeper Kubernetes service and cluster
 
-Once your Kubernetes cluster is created, you may create
-the Kafka cluster.
+Before you can run the Kafka cluster, you must
+start the zookeeper cluster.
 
-The first step is to create the service that will
+Tun the following command:
+
+```
+$ kubectl.sh create -f specs/zookeeper-cluster.yaml
+service "zoo1" created
+service "zoo2" created
+service "zoo3" created
+replicationcontroller "zookeeper-controller-1" created
+replicationcontroller "zookeeper-controller-2" created
+replicationcontroller "zookeeper-controller-3" created
+```
+
+This creates three internal services pointing to three
+distinct replication controllers. Each of them
+running a pod made of a single container.
+
+We have to do it this way because zookeeper currently
+expects static configuration between all nodes in the
+cluster.
+
+### Kafka Kubernetes service
+
+The next step is to create the service that will
 allow you to connect from the outside world to
 the Kafka cluster running in your infrastructure.
 
-This must be done beofre running the actual containers
+This must be done before running the actual containers
 in order for them to get the appropriate
 [environment variables](http://kubernetes.io/v1.1/docs/user-guide/services.html#environment-variables).
 
@@ -38,14 +60,13 @@ $ kubectl.sh create -f specs/kafka-service.yaml
 service "kafka-service" created
 ```
 
-On AWS, this will create a EC2 Load Balancer with two listeners
-for port `2181` (zookeeper) and `9092` (kafka) so that
-you can now connect to each.
+On AWS, this will create a EC2 Load Balancer with one listener
+for port `9092` (kafka).
 
 Note: This relies on the [service](http://kubernetes.io/v1.1/docs/user-guide/services.html)
 specification.
 
-### Kubernetes replication controller
+### Kafka Kubernetes replication controller
 
 
 Before you can run the containers, you must
@@ -55,10 +76,10 @@ variable. This must be set properly so that your
 kafka client can interact with the cluster.
 
 On AWS, you must set that value to the domain
-given to you by Amazon for the Load Balencer.
+given to you by Amazon for the Load Balancer.
 
 Next, you can create the Kubernetes replication controller
-that will pilot the kakfa and zookeeper containers:
+that will pilot the kakfa containers:
 
 ```
 $ kubectl.sh create -f specs/kafka-cluster.yaml
@@ -73,24 +94,19 @@ Monitor the status of the replication controller:
 
 ```
 $ kubectl.sh get rc
-CONTROLLER         CONTAINER(S)   IMAGE(S)                 SELECTOR    REPLICAS   AGE
-kafka-controller   kafka          ches/kafka               app=kafka   1          22m
-                   zookeeper      jplock/zookeeper:3.4.6  
 ```
 
 Monitor the status of the pods owning the containers:
 
 ```
 $ kubectl.sh get pods
-NAME                     READY     STATUS    RESTARTS   AGE
-kafka-controller-kugyh   2/2       Running   0          24m
 ```
 
 At this stage, the Kafka and Zookeeper processes should be
 running and listening for connection:
 
 ```
-$ kubectl.sh logs kafka-controller-kugyh -c zookeeper
+$ kubectl.sh logs zookeeper-controller-1-ajfrg -c zookeeper
 ...
 2016-01-23 13:29:52,532 [myid:] - INFO  [main:NIOServerCnxnFactory@94] - binding to port 0.0.0.0/0.0.0.0:2181
 ...

--- a/kafka/microservices/viewlib.py
+++ b/kafka/microservices/viewlib.py
@@ -21,7 +21,7 @@ async def webserver(loop, view, addr, port):
     return srv
 
 
-async def consume_events(topic, addr, callback, delay=0.01):
+async def consume_events(topic, group, addr, callback, delay=0.01):
     """
     Connect to the Kafka endpoint and start consuming
     messages from the given `topic`.
@@ -55,6 +55,8 @@ def get_cli_parser():
     parser.add_argument('--topic', dest='topic', action='store',
                         help='kafka topic to consume from',
                         required=True)
+    parser.add_argument('--group', dest='group', action='store',
+                        help='kafka group to consume from')
     parser.add_argument('--broker', dest='broker', action='store',
                         help='kafka broker address', required=True)
     parser.add_argument('--addr', dest='addr', action='store',
@@ -71,7 +73,8 @@ def run_view(loop, args, view, event_handler):
     within the given main asyncio loop.
     """
     coroutines = [
-        consume_events(topic=args.topic.encode(),
+        consume_events(topic=args.topic.encode('utf-8'),
+                       group=args.group,
                        addr=args.broker,
                        callback=event_handler),
         webserver(loop, view, addr=args.addr, port=args.port)

--- a/kafka/specs/create-topic-job.yaml
+++ b/kafka/specs/create-topic-job.yaml
@@ -17,5 +17,5 @@ spec:
       - name: create-topic
         image: ches/kafka
         command: ["kafka-topics.sh"]
-        args: ["--create --topic my-topic --replication-factor 1 --partitions 1 --zookeeper $(KAFKA_SERVICE_PORT_2181_TCP_ADDR):2181"]
+        args: ["--create --topic test1 --replication-factor 3 --partitions 2 --zookeeper zoo1:2181"]
       restartPolicy: Never

--- a/kafka/specs/kafka-cluster.yaml
+++ b/kafka/specs/kafka-cluster.yaml
@@ -14,15 +14,15 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: ches/kafka
+        image: wurstmeister/kafka
         ports:
         - containerPort: 9092
         env:
+        - name: KAFKA_ADVERTISED_PORT
+          value: "9092"
         - name: KAFKA_ADVERTISED_HOST_NAME
           value: <DOMAIN_OR_IP>
-      - name: zookeeper
-        image: jplock/zookeeper:3.4.6
-        ports:
-        - containerPort: 2181
-
-
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: zoo1:2181,zoo2:2181,zoo3:2181
+        - name: KAFKA_CREATE_TOPICS
+          value: mytopic:2:1

--- a/kafka/specs/kafka-service.yaml
+++ b/kafka/specs/kafka-service.yaml
@@ -11,10 +11,6 @@ spec:
     name: kafka-port
     targetPort: 9092
     protocol: TCP
-  - port: 2181
-    name: zookeeper-port
-    targetPort: 2181
-    protocol: TCP
   selector:
     app: kafka
   type: LoadBalancer

--- a/kafka/specs/zookeeper-cluster.yaml
+++ b/kafka/specs/zookeeper-cluster.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zoo1
+  labels:
+    app: zookeeper-1
+spec:
+  ports:
+  - name: client
+    port: 2181
+    protocol: TCP
+  - name: follower
+    port: 2888
+    protocol: TCP
+  - name: leader
+    port: 3888
+    protocol: TCP
+  selector:
+    app: zookeeper-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zoo2
+  labels:
+    app: zookeeper-2
+spec:
+  ports:
+  - name: client
+    port: 2181
+    protocol: TCP
+  - name: follower
+    port: 2888
+    protocol: TCP
+  - name: leader
+    port: 3888
+    protocol: TCP
+  selector:
+    app: zookeeper-2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zoo3
+  labels:
+    app: zookeeper-3
+spec:
+  ports:
+  - name: client
+    port: 2181
+    protocol: TCP
+  - name: follower
+    port: 2888
+    protocol: TCP
+  - name: leader
+    port: 3888
+    protocol: TCP
+  selector:
+    app: zookeeper-3
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: zookeeper-controller-1
+spec:
+  replicas: 1
+  selector:
+    app: zookeeper-1
+  template:
+    metadata:
+      labels:
+        app: zookeeper-1
+    spec:
+      containers:
+      - name: zoo1
+        image: digitalwonderland/zookeeper
+        ports:
+        - containerPort: 2181
+        env:
+        - name: ZOOKEEPER_ID
+          value: "1"
+        - name: ZOOKEEPER_SERVER_1
+          value: zoo1
+        - name: ZOOKEEPER_SERVER_2
+          value: zoo2
+        - name: ZOOKEEPER_SERVER_3
+          value: zoo3
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: zookeeper-controller-2
+spec:
+  replicas: 1
+  selector:
+    app: zookeeper-2
+  template:
+    metadata:
+      labels:
+        app: zookeeper-2
+    spec:
+      containers:
+      - name: zoo2
+        image: digitalwonderland/zookeeper
+        ports:
+        - containerPort: 2181
+        env:
+        - name: ZOOKEEPER_ID
+          value: "2"
+        - name: ZOOKEEPER_SERVER_1
+          value: zoo1
+        - name: ZOOKEEPER_SERVER_2
+          value: zoo2
+        - name: ZOOKEEPER_SERVER_3
+          value: zoo3
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: zookeeper-controller-3
+spec:
+  replicas: 1
+  selector:
+    app: zookeeper-3
+  template:
+    metadata:
+      labels:
+        app: zookeeper-3
+    spec:
+      containers:
+      - name: zoo3
+        image: digitalwonderland/zookeeper
+        ports:
+        - containerPort: 2181
+        env:
+        - name: ZOOKEEPER_ID
+          value: "3"
+        - name: ZOOKEEPER_SERVER_1
+          value: zoo1
+        - name: ZOOKEEPER_SERVER_2
+          value: zoo2
+        - name: ZOOKEEPER_SERVER_3
+          value: zoo3


### PR DESCRIPTION
Until now, only a single kafka/zookeper instance was up. This PR supports a 3-node zookeeper cluster and as many as you want kafka nodes (by scaling them via the replication controller).
