### PR TITLE
a simple cherrypy app with a single test

### DIFF
--- a/sampleservices/python/cherrypy-rest-service/microservice.py
+++ b/sampleservices/python/cherrypy-rest-service/microservice.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import cherrypy
+
+class Service(object):
+    @cherrypy.expose
+    def index(self):
+        return "Hello!"
+
+if __name__ == "__main__":
+    cherrypy.quickstart(Service())
+

--- a/sampleservices/python/cherrypy-rest-service/microservice_tests.py
+++ b/sampleservices/python/cherrypy-rest-service/microservice_tests.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import cherrypy
+from cherrypy.test import helper
+
+from microservice import Service
+
+class ServiceTest(helper.CPWebCase):
+    @staticmethod
+    def setup_server():
+        cherrypy.tree.mount(Service())
+        
+    def test_retrieve_resource(self):
+        self.getPage('/')
+        self.assertBody('Hello!')

--- a/sampleservices/python/cherrypy-rest-service/requirements.txt
+++ b/sampleservices/python/cherrypy-rest-service/requirements.txt
@@ -1,0 +1,3 @@
+nose
+pytest
+cherrypy


### PR DESCRIPTION
To run, first you need to install the dependencies:

$ pip install -r requirements.txt

Then you can run the test as follows:

$ py.test microservice_tests.py

We tend to use py.test a lot these days. Though the unittest module is still widely used too, py.test has quite interesting additional features.
